### PR TITLE
Fix admin imports and add permission hooks

### DIFF
--- a/e2e/setup.ts
+++ b/e2e/setup.ts
@@ -3,7 +3,7 @@ import { test as base, expect } from '@playwright/test'
 // Extend the base test to setup MSW.
 // This new `test` object will be used in all our E2E tests.
 export const test = base.extend({
-  page: async ({ page }, use) => {
+  page: async ({ page }, run) => {
     // We are adding an init script to run on the page before any other script.
     // This script will start the MSW service worker.
     await page.addInitScript(async () => {
@@ -11,7 +11,7 @@ export const test = base.extend({
       // Start the worker with quiet option to avoid excessive console logs.
       await worker.start({ quiet: true })
     })
-    await use(page)
+    await run(page)
   },
 })
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,7 +7,7 @@ import { globalIgnores } from 'eslint/config'
 import importPlugin from 'eslint-plugin-import'
 
 export default tseslint.config([
-  globalIgnores(['dist']),
+  globalIgnores(['dist', 'public/mockServiceWorker.js']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [
@@ -35,9 +35,7 @@ export default tseslint.config([
           ],
           alphabetize: { order: 'asc', caseInsensitive: true },
           'newlines-between': 'always',
-          pathGroups: [
-            { pattern: '@/**', group: 'internal', position: 'before' },
-          ],
+          pathGroups: [{ pattern: '@/**', group: 'internal', position: 'before' }],
           pathGroupsExcludedImportTypes: ['builtin'],
         },
       ],

--- a/src/features/admin/__tests__/AdminPanel.test.tsx
+++ b/src/features/admin/__tests__/AdminPanel.test.tsx
@@ -7,7 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { server } from '@/test/setup'
 
-import AdminPage from '../pages/Admin'
+import RolesPage from '../pages/RolesPage'
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -48,7 +48,7 @@ const AllTheProviders = ({ children }: { children: React.ReactNode }) => (
   </BrowserRouter>
 )
 
-const renderAdminPage = () => render(<AdminPage />, { wrapper: AllTheProviders })
+const renderRolesPage = () => render(<RolesPage />, { wrapper: AllTheProviders })
 
 describe('Admin Panel', () => {
   beforeEach(() => {
@@ -61,7 +61,7 @@ describe('Admin Panel', () => {
   })
 
   it('renders the role table successfully', async () => {
-    renderAdminPage()
+    renderRolesPage()
     expect(await screen.findByRole('table')).toBeInTheDocument()
     expect(screen.getByRole('cell', { name: 'ADMIN' })).toBeInTheDocument()
   })
@@ -72,13 +72,13 @@ describe('Admin Panel', () => {
         HttpResponse.json({ message: 'Failed to fetch' }, { status: 500 }),
       ),
     )
-    renderAdminPage()
+    renderRolesPage()
     expect(await screen.findByText(/Failed to fetch/i)).toBeInTheDocument()
   })
 
   it('opens create modal and shows validation error', async () => {
     const user = userEvent.setup()
-    renderAdminPage()
+    renderRolesPage()
 
     const createButton = await screen.findByRole('button', { name: /Create Role/i })
     await user.click(createButton)

--- a/src/features/admin/api/hooks.ts
+++ b/src/features/admin/api/hooks.ts
@@ -1,18 +1,20 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
 import {
-  createRole,
-  deleteRole,
-  listRoles,
-  updateRole,
-  type RoleRequest,
-} from '../services/role.service'
+  createPermission,
+  deletePermission,
+  listPermissions,
+  updatePermission,
+} from '../services/permission.service'
+import { createRole, deleteRole, listRoles, updateRole } from '../services/role.service'
 
-const queryKey = ['roles']
+import type { PermissionRequest, RoleRequest } from '../types'
+const rolesQueryKey = ['roles']
+const permissionsQueryKey = ['permissions']
 
 export function useGetRoles() {
   return useQuery({
-    queryKey,
+    queryKey: rolesQueryKey,
     queryFn: listRoles,
   })
 }
@@ -22,7 +24,7 @@ export function useCreateRole() {
   return useMutation({
     mutationFn: (data: RoleRequest) => createRole(data),
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey })
+      qc.invalidateQueries({ queryKey: rolesQueryKey })
     },
   })
 }
@@ -32,7 +34,7 @@ export function useUpdateRole() {
   return useMutation({
     mutationFn: ({ id, data }: { id: number; data: RoleRequest }) => updateRole(id, data),
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey })
+      qc.invalidateQueries({ queryKey: rolesQueryKey })
     },
   })
 }
@@ -42,7 +44,45 @@ export function useDeleteRole() {
   return useMutation({
     mutationFn: (id: number) => deleteRole(id),
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey })
+      qc.invalidateQueries({ queryKey: rolesQueryKey })
+    },
+  })
+}
+
+export function useGetPermissions() {
+  return useQuery({
+    queryKey: permissionsQueryKey,
+    queryFn: listPermissions,
+  })
+}
+
+export function useCreatePermission() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (data: PermissionRequest) => createPermission(data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: permissionsQueryKey })
+    },
+  })
+}
+
+export function useUpdatePermission() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, data }: { id: number; data: PermissionRequest }) =>
+      updatePermission(id, data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: permissionsQueryKey })
+    },
+  })
+}
+
+export function useDeletePermission() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (id: number) => deletePermission(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: permissionsQueryKey })
     },
   })
 }

--- a/src/features/admin/components/EditRoleModal.tsx
+++ b/src/features/admin/components/EditRoleModal.tsx
@@ -18,7 +18,8 @@ import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 
 import { useUpdateRole } from '../api/hooks'
-import { type Role } from '../services/role.service'
+
+import type { Role } from '../types'
 
 const updateRoleSchema = z.object({
   name: z.string().min(1, 'Role name is required'),

--- a/src/features/admin/components/PermissionForm.tsx
+++ b/src/features/admin/components/PermissionForm.tsx
@@ -3,7 +3,7 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 
-import { PermissionRequest } from '@/features/admin/types'
+import type { PermissionRequest } from '@/features/admin/types'
 import { permissionSchema } from '@/features/admin/types/permission.zod'
 
 type PermissionFormValues = z.infer<typeof permissionSchema>

--- a/src/features/admin/index.ts
+++ b/src/features/admin/index.ts
@@ -1,1 +1,4 @@
-export { default as Admin } from './pages/Admin'
+export { default as AdminLayout } from './components/AdminLayout'
+export { default as AdminIndexPage } from './pages/AdminIndexPage'
+export { default as PermissionsPage } from './pages/PermissionsPage'
+export { default as RolesPage } from './pages/RolesPage'

--- a/src/features/admin/pages/AdminIndexPage.tsx
+++ b/src/features/admin/pages/AdminIndexPage.tsx
@@ -1,0 +1,10 @@
+import { Heading, Stack, Text } from '@chakra-ui/react'
+
+export default function AdminIndexPage() {
+  return (
+    <Stack spacing={4}>
+      <Heading size="lg">Admin Panel</Heading>
+      <Text>Select a section from the navigation menu.</Text>
+    </Stack>
+  )
+}

--- a/src/features/admin/pages/PermissionsPage.tsx
+++ b/src/features/admin/pages/PermissionsPage.tsx
@@ -37,7 +37,8 @@ import {
   useUpdatePermission,
 } from '../api/hooks'
 import { PermissionForm } from '../components/PermissionForm'
-import { Permission, PermissionRequest } from '../types'
+
+import type { Permission, PermissionRequest } from '../types'
 
 const PermissionsPage = () => {
   const { data: permissions, isLoading, isError, error } = useGetPermissions()
@@ -113,7 +114,7 @@ const PermissionsPage = () => {
             </Tr>
           </Thead>
           <Tbody>
-            {permissions.map((permission) => (
+            {permissions.map((permission: Permission) => (
               <Tr key={permission.id}>
                 <Td>{permission.id}</Td>
                 <Td>{permission.name}</Td>

--- a/src/features/admin/pages/RolesPage.tsx
+++ b/src/features/admin/pages/RolesPage.tsx
@@ -2,8 +2,6 @@ import {
   Alert,
   AlertIcon,
   AlertTitle,
-  Box,
-  Flex,
   Heading,
   HStack,
   IconButton,
@@ -12,22 +10,21 @@ import {
   Table,
   Tbody,
   Td,
-  Text,
   Th,
   Thead,
   Tr,
+  Button,
+  useDisclosure,
 } from '@chakra-ui/react'
-import { Button, useDisclosure } from '@chakra-ui/react'
 import React from 'react'
 import { FaEdit, FaTrash } from 'react-icons/fa'
-
-import { Footer, Header } from '@/shared/ui/PageLayout'
 
 import { useDeleteRole, useGetRoles } from '../api/hooks'
 import { ConfirmationModal } from '../components/ConfirmationModal'
 import { CreateRoleModal } from '../components/CreateRoleModal'
 import { EditRoleModal } from '../components/EditRoleModal'
-import { type Role } from '../services/role.service'
+
+import type { Role } from '../types'
 
 function RoleManagement() {
   const { data: roles, isLoading, isError, error } = useGetRoles()
@@ -88,58 +85,43 @@ function RoleManagement() {
           </Button>
         </HStack>
         <Table variant="simple">
-        <Thead>
-          <Tr>
-            <Th>ID</Th>
-            <Th>Name</Th>
-            <Th>Actions</Th>
-          </Tr>
-        </Thead>
-        <Tbody>
-          {roles?.map((role) => (
-            <Tr key={role.id}>
-              <Td>{role.id}</Td>
-              <Td>{role.name}</Td>
-              <Td>
-                <HStack>
-                  <IconButton
-                    aria-label="Edit role"
-                    icon={<FaEdit />}
-                    size="sm"
-                    onClick={() => handleEditClick(role)}
-                  />
-                  <IconButton
-                    aria-label="Delete role"
-                    icon={<FaTrash />}
-                    size="sm"
-                    onClick={() => handleDeleteClick(role)}
-                  />
-                </HStack>
-              </Td>
+          <Thead>
+            <Tr>
+              <Th>ID</Th>
+              <Th>Name</Th>
+              <Th>Actions</Th>
             </Tr>
-          ))}
-        </Tbody>
-      </Table>
-    </Stack>
+          </Thead>
+          <Tbody>
+            {roles?.map((role) => (
+              <Tr key={role.id}>
+                <Td>{role.id}</Td>
+                <Td>{role.name}</Td>
+                <Td>
+                  <HStack>
+                    <IconButton
+                      aria-label="Edit role"
+                      icon={<FaEdit />}
+                      size="sm"
+                      onClick={() => handleEditClick(role)}
+                    />
+                    <IconButton
+                      aria-label="Delete role"
+                      icon={<FaTrash />}
+                      size="sm"
+                      onClick={() => handleDeleteClick(role)}
+                    />
+                  </HStack>
+                </Td>
+              </Tr>
+            ))}
+          </Tbody>
+        </Table>
+      </Stack>
     </>
   )
 }
 
-export default function Admin() {
-  return (
-    <Flex direction="column" minH="100vh">
-      <Header showSearchBar={false} />
-      <Box as="main" flex={1} p={8}>
-        <Stack spacing={4}>
-          <Heading size="lg">Admin Panel</Heading>
-          <Text>This is a restricted area. Only admins can see this.</Text>
-          <Box as="section" mt={8}>
-            <RoleManagement />
-          </Box>
-        </Stack>
-      </Box>
-      <Footer />
-    </Flex>
-  )
+export default function RolesPage() {
+  return <RoleManagement />
 }
-

--- a/src/features/admin/services/permission.service.ts
+++ b/src/features/admin/services/permission.service.ts
@@ -1,0 +1,40 @@
+import http, { toApiError } from '@/shared/lib/fetcher'
+
+import type { Permission, PermissionRequest } from '../types'
+
+const permissionsBaseUrl = '/iam/api/v1/permissions'
+
+export async function listPermissions(): Promise<Permission[]> {
+  try {
+    const res = await http.get<Permission[]>(permissionsBaseUrl)
+    return res.data
+  } catch (err) {
+    throw toApiError(err)
+  }
+}
+
+export async function createPermission(data: PermissionRequest): Promise<Permission> {
+  try {
+    const res = await http.post<Permission>(permissionsBaseUrl, data)
+    return res.data
+  } catch (err) {
+    throw toApiError(err)
+  }
+}
+
+export async function updatePermission(id: number, data: PermissionRequest): Promise<Permission> {
+  try {
+    const res = await http.put<Permission>(`${permissionsBaseUrl}/${id}`, data)
+    return res.data
+  } catch (err) {
+    throw toApiError(err)
+  }
+}
+
+export async function deletePermission(id: number): Promise<void> {
+  try {
+    await http.delete(`${permissionsBaseUrl}/${id}`)
+  } catch (err) {
+    throw toApiError(err)
+  }
+}

--- a/src/features/admin/services/role.service.ts
+++ b/src/features/admin/services/role.service.ts
@@ -1,6 +1,6 @@
 import http, { toApiError } from '@/shared/lib/fetcher'
 
-import { Role, RoleRequest } from '../types'
+import type { Role, RoleRequest } from '../types'
 
 const rolesBaseUrl = '/iam/api/v1/roles'
 

--- a/src/features/admin/types/permission.zod.ts
+++ b/src/features/admin/types/permission.zod.ts
@@ -1,0 +1,6 @@
+import { z } from 'zod'
+
+export const permissionSchema = z.object({
+  name: z.string().min(1, 'Name is required'),
+  description: z.string().optional(),
+})


### PR DESCRIPTION
## Summary
- adjust admin feature export structure and rename roles page
- add permission service and hooks with zod schema
- ignore generated service worker in eslint and cleanup e2e setup

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68c009e83ecc832e9d34271b0466ec33