### PR TITLE
Ensure catalog and admin pages push footer below fold

### DIFF
--- a/src/features/admin/components/AdminLayout.tsx
+++ b/src/features/admin/components/AdminLayout.tsx
@@ -17,9 +17,9 @@ const AdminLayout = () => {
   const { isOpen, onToggle } = useDisclosure({ defaultIsOpen: true })
 
   return (
-    <Flex direction="column" minH="100vh">
+    <Flex direction="column">
       <Header showSearchBar={false} />
-      <Flex flex="1" position="relative">
+      <Flex flex="1" minH="calc(100vh + 1px)" position="relative">
         {isOpen && (
           <Box as="nav" width="250px" bg="gray.100" p={4} position="relative">
             <Heading as="h1" size="lg" mb={8}>

--- a/src/features/catalog/pages/CatalogList.tsx
+++ b/src/features/catalog/pages/CatalogList.tsx
@@ -62,9 +62,9 @@ export default function CatalogList() {
   }
 
   return (
-    <Flex direction="column" minH="100vh">
+    <Flex direction="column">
       <Header />
-      <Box as="main" flex={1} px={6} py={6}>
+      <Box as="main" flex={1} minH="calc(100vh + 1px)" px={6} py={6}>
         <Stack spacing={4}>
           <HStack justify="space-between">
             <Heading size="lg">Products</Heading>


### PR DESCRIPTION
## Summary
- move min-height from outer flex to main content in catalog list
- apply same layout fix to admin layout

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run build`
- `npm run dev` (manual)


------
https://chatgpt.com/codex/tasks/task_e_68c0d68b2ca0832eb247d57b397c5e7b