### PR TITLE
feat(profile): add avatar cropping before upload

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "framer-motion": "^10.18.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-easy-crop": "^5.5.2",
         "react-hook-form": "^7.62.0",
         "react-icons": "^5.5.0",
         "react-router-dom": "^6.30.1",
@@ -6418,6 +6419,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/normalize-wheel": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-wheel/-/normalize-wheel-1.0.1.tgz",
+      "integrity": "sha512-1OnlAPZ3zgrk8B91HyRj+eVv+kS5u+Z0SCsak6Xil/kmgEia50ga7zfkumayonZrImffAxPU/5WcyGhzetHNPA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/nwsapi": {
       "version": "2.2.21",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.21.tgz",
@@ -7170,6 +7177,20 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-easy-crop": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/react-easy-crop/-/react-easy-crop-5.5.2.tgz",
+      "integrity": "sha512-8sxx7x7QBMF8fi+zd9QTf9MXovPzQUASNCRrXy/ZUQe9r25U0yDweyM38CaoNTAfX9+k/v52ywLRXiwDN3TBtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "normalize-wheel": "^1.0.1",
+        "tslib": "^2.0.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.4.0",
+        "react-dom": ">=16.4.0"
       }
     },
     "node_modules/react-fast-compare": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "framer-motion": "^10.18.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-easy-crop": "^5.5.2",
     "react-hook-form": "^7.62.0",
     "react-icons": "^5.5.0",
     "react-router-dom": "^6.30.1",

--- a/src/features/profile/components/AvatarCropModal.tsx
+++ b/src/features/profile/components/AvatarCropModal.tsx
@@ -1,0 +1,162 @@
+import {
+  Box,
+  Button,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Slider,
+  SliderFilledTrack,
+  SliderThumb,
+  SliderTrack,
+  Stack,
+  Text,
+} from '@chakra-ui/react'
+import { useEffect, useMemo, useState, type ReactNode } from 'react'
+import Cropper, { type Area } from 'react-easy-crop'
+
+import { cropImageToBlob } from '../lib/cropImage'
+
+type AvatarCropModalProps = {
+  file: File | null
+  isOpen: boolean
+  onCancel: () => void
+  onConfirm: (file: File) => Promise<void> | void
+  footerExtra?: ReactNode
+}
+
+const ZOOM_MIN = 1
+const ZOOM_MAX = 3
+const ZOOM_STEP = 0.1
+
+export default function AvatarCropModal({
+  file,
+  isOpen,
+  onCancel,
+  onConfirm,
+  footerExtra,
+}: AvatarCropModalProps) {
+  const [imageUrl, setImageUrl] = useState<string | null>(null)
+  const [crop, setCrop] = useState({ x: 0, y: 0 })
+  const [zoom, setZoom] = useState(1.2)
+  const [croppedAreaPixels, setCroppedAreaPixels] = useState<Area | null>(null)
+  const [isProcessing, setIsProcessing] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!file) {
+      setImageUrl(null)
+      return
+    }
+
+    const url = URL.createObjectURL(file)
+    setImageUrl(url)
+    return () => {
+      URL.revokeObjectURL(url)
+    }
+  }, [file])
+
+  useEffect(() => {
+    if (isOpen) {
+      setCrop({ x: 0, y: 0 })
+      setZoom(1.2)
+      setCroppedAreaPixels(null)
+      setError(null)
+    }
+  }, [isOpen])
+
+  const outputType = useMemo(() => {
+    if (!file?.type) return 'image/png'
+    return file.type.startsWith('image/') ? file.type : 'image/png'
+  }, [file])
+
+  if (!file) {
+    return null
+  }
+
+  async function handleConfirm() {
+    if (!imageUrl || !croppedAreaPixels) {
+      setError('Unable to crop image, please try again.')
+      return
+    }
+
+    setIsProcessing(true)
+    setError(null)
+    try {
+      const blob = await cropImageToBlob(imageUrl, croppedAreaPixels, outputType)
+      const croppedFile = new File([blob], file.name, { type: blob.type })
+      await onConfirm(croppedFile)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to crop image')
+    } finally {
+      setIsProcessing(false)
+    }
+  }
+
+  return (
+    <Modal isOpen={isOpen} onClose={onCancel} size="xl" isCentered>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Adjust Avatar</ModalHeader>
+        <ModalCloseButton disabled={isProcessing} />
+        <ModalBody>
+          <Stack spacing={4}>
+            <Box position="relative" w="full" pt="100%" bg="gray.900" borderRadius="lg" overflow="hidden">
+              {imageUrl ? (
+                <Cropper
+                  image={imageUrl}
+                  crop={crop}
+                  zoom={zoom}
+                  aspect={1}
+                  onCropChange={setCrop}
+                  onZoomChange={setZoom}
+                  onCropComplete={(_, areaPixels) => setCroppedAreaPixels(areaPixels)}
+                  objectFit="cover"
+                  zoomWithScroll
+                />
+              ) : null}
+            </Box>
+            <Box>
+              <Text fontWeight="medium" mb={2}>
+                Zoom
+              </Text>
+              <Slider
+                min={ZOOM_MIN}
+                max={ZOOM_MAX}
+                step={ZOOM_STEP}
+                value={zoom}
+                onChange={setZoom}
+                isDisabled={isProcessing}
+                aria-label="Zoom"
+              >
+                <SliderTrack>
+                  <SliderFilledTrack />
+                </SliderTrack>
+                <SliderThumb />
+              </Slider>
+            </Box>
+            {error ? (
+              <Text color="red.500" fontSize="sm">
+                {error}
+              </Text>
+            ) : null}
+          </Stack>
+        </ModalBody>
+        <ModalFooter>
+          <Stack direction={{ base: 'column', sm: 'row' }} spacing={3} w="full" justify="flex-end">
+            <Button variant="ghost" onClick={onCancel} isDisabled={isProcessing}>
+              Cancel
+            </Button>
+            {footerExtra}
+            <Button colorScheme="teal" onClick={handleConfirm} isLoading={isProcessing}>
+              Save
+            </Button>
+          </Stack>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  )
+}

--- a/src/features/profile/lib/cropImage.ts
+++ b/src/features/profile/lib/cropImage.ts
@@ -1,0 +1,55 @@
+import type { Area } from 'react-easy-crop'
+
+function loadImage(src: string) {
+  return new Promise<HTMLImageElement>((resolve, reject) => {
+    const image = new Image()
+    image.addEventListener('load', () => resolve(image))
+    image.addEventListener('error', () => reject(new Error('Unable to load image')))
+    image.setAttribute('crossOrigin', 'anonymous')
+    image.src = src
+  })
+}
+
+export async function cropImageToBlob(
+  imageSrc: string,
+  cropArea: Area,
+  outputType: string,
+  quality = 0.92,
+) {
+  const image = await loadImage(imageSrc)
+  const canvas = document.createElement('canvas')
+  const context = canvas.getContext('2d')
+
+  if (!context) {
+    throw new Error('Failed to create canvas context')
+  }
+
+  canvas.width = cropArea.width
+  canvas.height = cropArea.height
+
+  context.drawImage(
+    image,
+    cropArea.x,
+    cropArea.y,
+    cropArea.width,
+    cropArea.height,
+    0,
+    0,
+    cropArea.width,
+    cropArea.height,
+  )
+
+  return new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => {
+        if (blob) {
+          resolve(blob)
+        } else {
+          reject(new Error('Failed to crop image'))
+        }
+      },
+      outputType,
+      quality,
+    )
+  })
+}


### PR DESCRIPTION
## Summary
- add an avatar cropper modal that lets users adjust their profile photo before uploading
- process cropped output client-side before requesting the minio upload URL and preview the new avatar
- add the react-easy-crop dependency and a helper to generate cropped blobs

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d811ecd2b8832e9034b0344ebfb5e6