### PR TITLE
Show profile avatar and name in header menu

### DIFF
--- a/src/features/profile/api/hooks.ts
+++ b/src/features/profile/api/hooks.ts
@@ -23,9 +23,10 @@ const PROFILE_QUERY_KEY = ['profile', 'me'] as const
 const AVATAR_QUERY_KEY = ['profile', 'avatar'] as const
 const STORES_QUERY_KEY = ['profile', 'stores'] as const
 
-export function useMyProfile() {
+export function useMyProfile(options?: { enabled?: boolean }) {
   return useQuery<UserProfileDto, ApiError>({
     queryKey: PROFILE_QUERY_KEY,
+    enabled: options?.enabled ?? true,
     queryFn: () => getMyProfileService(),
     staleTime: 60_000,
   })

--- a/src/features/profile/components/AvatarCropModal.tsx
+++ b/src/features/profile/components/AvatarCropModal.tsx
@@ -78,7 +78,7 @@ export default function AvatarCropModal({
   }
 
   async function handleConfirm() {
-    if (!imageUrl || !croppedAreaPixels) {
+    if (!imageUrl || !croppedAreaPixels || !file) {
       setError('Unable to crop image, please try again.')
       return
     }
@@ -113,7 +113,7 @@ export default function AvatarCropModal({
                   aspect={1}
                   onCropChange={setCrop}
                   onZoomChange={setZoom}
-                  onCropComplete={(_, areaPixels) => setCroppedAreaPixels(areaPixels)}
+                  onCropComplete={(_, areaPixels: Area) => setCroppedAreaPixels(areaPixels)}
                   objectFit="cover"
                   zoomWithScroll
                 />

--- a/src/shared/ui/PageLayout.tsx
+++ b/src/shared/ui/PageLayout.tsx
@@ -20,6 +20,7 @@ import { Link as RouterLink, useSearchParams } from 'react-router-dom'
 
 import { useCurrentUser, useLogout } from '@/features/auth/api/hooks'
 import useAuth from '@/features/auth/useAuth'
+import { useAvatarViewUrl, useMyProfile } from '@/features/profile/api/hooks'
 
 export function Header({ showSearchBar = true }: { showSearchBar?: boolean }) {
   const [searchParams, setSearchParams] = useSearchParams()
@@ -28,6 +29,16 @@ export function Header({ showSearchBar = true }: { showSearchBar?: boolean }) {
   const logout = useLogout()
   const user = useCurrentUser()
   const { isAuthenticated } = useAuth()
+  const profileQuery = useMyProfile({ enabled: isAuthenticated })
+  const profile = profileQuery.data
+  const avatarKey = isAuthenticated ? profile?.avatarObjectKey ?? null : null
+  const avatarQuery = useAvatarViewUrl(avatarKey)
+  const avatarUrl = avatarQuery.data?.url ?? undefined
+  const username = user.data?.username ?? null
+  const rawFullName = profile?.fullName ?? ''
+  const fullName = rawFullName ? rawFullName.trim() : ''
+  const displayName = fullName || username || 'User'
+  const displayUsername = username ? `@${username}` : null
   const closeTimer = React.useRef<number | null>(null)
 
   const clearCloseTimer = () => {
@@ -77,17 +88,17 @@ export function Header({ showSearchBar = true }: { showSearchBar?: boolean }) {
           {isAuthenticated ? (
             <Menu isOpen={isOpen} closeOnBlur={false}>
               <MenuButton onMouseEnter={openOnHover} onMouseLeave={scheduleClose}>
-                <Avatar size="sm" name={user.data?.username || 'User'} />
+                <Avatar size="sm" name={displayName} src={avatarUrl} />
               </MenuButton>
               <MenuList onMouseEnter={openOnHover} onMouseLeave={scheduleClose}>
                 <Box px={3} py={2}>
                   <HStack>
-                    <Avatar size="sm" name={user.data?.username || 'User'} />
+                    <Avatar size="sm" name={displayName} src={avatarUrl} />
                     <Box>
-                      <Text fontWeight="semibold">{user.data?.username || 'User'}</Text>
-                      {user.data?.email && (
+                      <Text fontWeight="semibold">{displayName}</Text>
+                      {displayUsername && (
                         <Text fontSize="sm" color="gray.500">
-                          {user.data.email}
+                          {displayUsername}
                         </Text>
                       )}
                     </Box>

--- a/src/types/react-easy-crop.d.ts
+++ b/src/types/react-easy-crop.d.ts
@@ -1,0 +1,32 @@
+declare module 'react-easy-crop' {
+  import * as React from 'react'
+
+  export interface Area {
+    x: number
+    y: number
+    width: number
+    height: number
+  }
+
+  export interface Point {
+    x: number
+    y: number
+  }
+
+  export interface CropperProps {
+    image: string
+    crop: Point
+    zoom: number
+    aspect?: number
+    onCropChange?: (location: Point) => void
+    onZoomChange?: (zoom: number) => void
+    onCropComplete?: (croppedArea: Area, croppedAreaPixels: Area) => void
+    objectFit?: 'contain' | 'cover'
+    zoomWithScroll?: boolean
+  }
+
+  const Cropper: React.FC<CropperProps>
+
+  export default Cropper
+  export type { Area }
+}


### PR DESCRIPTION
## Summary
- load profile data in the header to render the profile full name and avatar URL
- allow skipping the my-profile query when unauthenticated and reuse the avatar URL hook
- add minimal react-easy-crop type declarations and null checks to keep type checking green

## Testing
- npm run lint
- npm run typecheck
- npm run vitest
- npm run test:e2e

------
https://chatgpt.com/codex/tasks/task_e_68d8194dcd8c832ea9d1b04b7fb678a1