### PR TITLE
Refresh profile store list after creating a store

### DIFF
--- a/src/features/profile/components/CreateStoreModal.tsx
+++ b/src/features/profile/components/CreateStoreModal.tsx
@@ -27,6 +27,7 @@ import { storeFormSchema, type StoreFormValues } from '../lib/schemas'
 type CreateStoreModalProps = {
   isOpen: boolean
   onClose: () => void
+  onSuccess?: () => void
 }
 
 function slugify(value: string) {
@@ -37,7 +38,7 @@ function slugify(value: string) {
     .replace(/^-+|-+$/g, '')
 }
 
-export default function CreateStoreModal({ isOpen, onClose }: CreateStoreModalProps) {
+export default function CreateStoreModal({ isOpen, onClose, onSuccess }: CreateStoreModalProps) {
   const toast = useToast()
   const { refresh } = useAuth()
   const { mutateAsync, isPending } = useCreateStore()
@@ -76,6 +77,7 @@ export default function CreateStoreModal({ isOpen, onClose }: CreateStoreModalPr
         slug: values.slug.trim(),
         description: values.description?.trim() ? values.description.trim() : null,
       })
+      onSuccess?.()
       toast({ title: 'Store created', status: 'success' })
       onClose()
       await refresh().catch(() => null)

--- a/src/features/profile/pages/MyProfilePage.tsx
+++ b/src/features/profile/pages/MyProfilePage.tsx
@@ -12,6 +12,7 @@ import {
   Text,
   useDisclosure,
 } from '@chakra-ui/react'
+import { useState } from 'react'
 
 import { useCurrentUser } from '@/features/auth/api/hooks'
 import { Footer, Header } from '@/shared/ui/PageLayout'
@@ -32,7 +33,9 @@ export default function MyProfilePage() {
   const { data: currentUser } = useCurrentUser()
   const roles = currentUser?.roles ?? []
   const canManageStores = roles.includes('SELLER') || roles.includes('ADMIN')
-  const storesQuery = useMyStores({ enabled: canManageStores })
+  const [hasCreatedStore, setHasCreatedStore] = useState(false)
+  const shouldLoadStores = canManageStores || hasCreatedStore
+  const storesQuery = useMyStores({ enabled: shouldLoadStores })
   const { isOpen, onOpen, onClose } = useDisclosure()
 
   return (
@@ -54,7 +57,7 @@ export default function MyProfilePage() {
         ) : profile ? (
           <Stack spacing={8}>
             <ProfileDetailsCard profile={profile} avatarUrl={avatarQuery.data?.url ?? null} />
-            {canManageStores ? (
+            {shouldLoadStores ? (
               <StoresSection
                 stores={storesQuery.data}
                 isLoading={storesQuery.isLoading}
@@ -81,7 +84,14 @@ export default function MyProfilePage() {
         ) : null}
       </Box>
       <Footer />
-      <CreateStoreModal isOpen={isOpen} onClose={onClose} />
+      <CreateStoreModal
+        isOpen={isOpen}
+        onClose={onClose}
+        onSuccess={() => {
+          setHasCreatedStore(true)
+          void storesQuery.refetch()
+        }}
+      />
     </Flex>
   )
 }


### PR DESCRIPTION
## Summary
- track local store creation state on My Profile page to enable store queries once a user creates a new store
- allow CreateStoreModal to accept an optional success callback and notify the page immediately after a store is created
- refetch the store list when the modal succeeds so the StoresSection appears without a full refresh

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9e489c5f0832ea74648b0715d5d31