### PR TITLE
Hide new store button when store already exists

### DIFF
--- a/src/features/profile/components/StoresSection.tsx
+++ b/src/features/profile/components/StoresSection.tsx
@@ -32,6 +32,7 @@ export default function StoresSection({ stores, isLoading, isError, error, onCre
   const toast = useToast()
   const { mutateAsync: updateStore } = useUpdateStore()
   const [updatingId, setUpdatingId] = useState<string | null>(null)
+  const canCreateStore = !isLoading && !isError && (!stores || stores.length === 0)
 
   async function toggleActive(store: StoreProfileDto, next: boolean) {
     setUpdatingId(store.id)
@@ -51,9 +52,11 @@ export default function StoresSection({ stores, isLoading, isError, error, onCre
       <CardHeader>
         <HStack justify="space-between" align="center">
           <Text fontWeight="semibold">My Stores</Text>
-          <Button size="sm" colorScheme="teal" onClick={onCreateStore}>
-            New Store
-          </Button>
+          {canCreateStore ? (
+            <Button size="sm" colorScheme="teal" onClick={onCreateStore}>
+              New Store
+            </Button>
+          ) : null}
         </HStack>
       </CardHeader>
       <CardBody>


### PR DESCRIPTION
## Summary
- prevent additional store creation by hiding the New Store button when an account already has a store
- keep the rest of the store management UI unchanged

## Testing
- npm run typecheck
- npm run lint
- npm run vitest
- npm run test:e2e

------
https://chatgpt.com/codex/tasks/task_e_68de9bb4e2ec832e8a67a76ce202be49